### PR TITLE
Make sure we are using unaliased grep

### DIFF
--- a/scripts/copycat_jump.sh
+++ b/scripts/copycat_jump.sh
@@ -27,7 +27,7 @@ _get_result_line() {
 _string_starts_with_digit() {
 	local string="$1"
 	echo "$string" |
-		grep -q '^[[:digit:]]\+:'
+		\grep -q '^[[:digit:]]\+:'
 }
 
 _get_line_number() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -144,7 +144,7 @@ copycat_quit_copy_mode_keys() {
 	local commands_that_quit_copy_mode="cancel\|copy-selection\|copy-pipe"
 	local copy_mode="$(tmux_copy_mode)-copy"
 	tmux list-keys -t "$copy_mode" |
-		grep "$commands_that_quit_copy_mode" |
+		\grep "$commands_that_quit_copy_mode" |
 		awk '{ print $4}' |
 		sort -u |
 		xargs echo

--- a/scripts/stored_search_helpers.sh
+++ b/scripts/stored_search_helpers.sh
@@ -6,7 +6,7 @@ stored_search_not_defined() {
 
 stored_search_vars() {
 	tmux show-options -g |
-		grep -i "^${COPYCAT_VAR_PREFIX}_" |
+		\grep -i "^${COPYCAT_VAR_PREFIX}_" |
 		cut -d ' ' -f1 |               # cut just variable names
 		xargs                          # splat var names in one line
 }

--- a/test/run-tests-within-vm
+++ b/test/run-tests-within-vm
@@ -7,7 +7,7 @@ tests_exit_value=0
 
 test_files() {
 	ls -1 $CURRENT_DIR |        # test files are in current dir
-		grep -i '^test' |       # test file names start with 'test'
+		\grep -i '^test' |       # test file names start with 'test'
 		xargs                   # file names in one line
 }
 


### PR DESCRIPTION
Hi there,
first off thanks for you plugins, I'm just starting to use them but I find them very useful.
I found that I'm having problems running tmux-copycat on my (Linux) system where I have an alias for grep.
(I'm not sure as to why the alias is being used in copycat in the first place).
