### PR TITLE
Improve tempfile handling

### DIFF
--- a/scripts/copycat_generate_results.sh
+++ b/scripts/copycat_generate_results.sh
@@ -23,13 +23,14 @@ reverse_and_create_copycat_file() {
 delete_old_files() {
 	local scrollback_filename="$(get_scrollback_filename)"
 	local copycat_filename="$(get_copycat_filename)"
-	rm "$scrollback_filename" "$copycat_filename"
+	rm -f "$scrollback_filename" "$copycat_filename"
 }
 
 generate_copycat_file() {
 	local grep_pattern="$1"
 	local scrollback_filename="$(get_scrollback_filename)"
 	local copycat_filename="$(get_copycat_filename)"
+	mkdir -p "$(_get_tmp_dir)"
 	capture_pane "$scrollback_filename"
 	reverse_and_create_copycat_file "$scrollback_filename" "$copycat_filename" "$grep_pattern"
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -75,11 +75,11 @@ reset_copycat_position() {
 # === scrollback and results position ===
 
 get_scrollback_filename() {
-	echo "$(_get_tmp_dir)/tmux_scrollback_$(_pane_unique_id)"
+	echo "$(_get_tmp_dir)/scrollback-$(_pane_unique_id)"
 }
 
 get_copycat_filename() {
-	echo "$(_get_tmp_dir)/tmux_copycat_$(_pane_unique_id)"
+	echo "$(_get_tmp_dir)/results-$(_pane_unique_id)"
 }
 
 # Ensures a message is displayed for 5 seconds in tmux prompt.
@@ -163,16 +163,12 @@ _copycat_position_var() {
 }
 
 _get_tmp_dir() {
-	if [ -n "$TMPDIR" ]; then
-		echo "$TMPDIR"
-	else
-		echo "/tmp/"
-	fi
+	echo "${TMPDIR:-/tmp}/tmux-$EUID-copycat"
 }
 
 # returns a string unique to current pane
 # sed removes `$` sign because `session_id` contains is
 _pane_unique_id() {
-	tmux display-message -p "#{session_id}_#{window_index}_#{pane_index}" |
+	tmux display-message -p "#{session_id}-#{window_index}-#{pane_index}" |
 		sed 's/\$//'
 }


### PR DESCRIPTION
Just some small optimizations:
- move tempfiles into a subdirectory to keep `/tmp` clean
- capture pane directly to tempfile, don't go through tmux buffer

Tests are still passing!
