### PR TITLE
Add stored search for matching email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### master
 - if installed use `gawk` instead of `awk` (@metcalfc)
 - add stored search for matching git SHAs (@jbnicolai)
+- add stored search for matching email addresses (@davidjb)
 
 ### v2.1.0, Jan 01, 2015
 - combine send-keys calls to reduce flickering (@toupeira)

--- a/copycat.tmux
+++ b/copycat.tmux
@@ -13,6 +13,7 @@ set_default_stored_searches() {
 	local digit_search="$(get_tmux_option "$copycat_digit_search_option" "$default_digit_search_key")"
 	local hash_search="$(get_tmux_option "$copycat_hash_search_option" "$default_hash_search_key")"
 	local ip_search="$(get_tmux_option "$copycat_ip_search_option" "$default_ip_search_key")"
+	local email_search="$(get_tmux_option "$copycat_email_search_option" "$default_email_search_key")"
 
 	if stored_search_not_defined "$url_search"; then
 		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${url_search}" "(https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*"
@@ -28,6 +29,9 @@ set_default_stored_searches() {
 	fi
 	if stored_search_not_defined "$ip_search"; then
 		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${ip_search}" "[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}"
+	fi
+	if stored_search_not_defined "$email_search"; then
+		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${email_search}" '[[:alnum:].!#$%&*+/=?^_\`{|}~-]+@[[:alnum:]-]+(\.[[:alnum:]]+)*'
 	fi
 }
 

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -24,3 +24,6 @@ copycat_hash_search_option="@copycat_hash_search"
 
 default_ip_search_key="M-i"
 copycat_ip_search_option="@copycat_ip_search"
+
+default_email_search_key="C-e"
+copycat_email_search_option="@copycat_email_search"

--- a/test/README.md
+++ b/test/README.md
@@ -13,3 +13,26 @@ Tests are written with the [expect tool](http://expect.sourceforge.net/).
 From the `tmux copycat` project top directory run:
 
     $ ./run-tests
+
+### Debugging tests
+
+In your tests, you can add a call to expect's interactive debugger with
+``debug 1`` where you'd like to start debugging.
+
+From the `tmux copycat` project top directory, bring up and access the given Vagrant VM:
+
+    $ vagrant up [ubuntu|centos]
+    $ vagrant ssh [ubuntu|centos]
+
+and inside the VM, run the tests manually:
+
+    $ cd /vagrant
+    $ ./test/run-tests-within-vm
+
+During this process, you can watch the progress of the tests interactively
+by attaching yourself to the existing ``tmux`` server within the VM by
+running ``tmux attach-session``.  Note that there may be multiple sessions
+and windows in use, depending on how many times your tests have run, so
+check through each until you find the applicable one.  Take care not to
+disrupt the tests whilst running or you will encounter false results!
+

--- a/test/helpers/expect_copycat_assertions.exp
+++ b/test/helpers/expect_copycat_assertions.exp
@@ -39,9 +39,10 @@ proc _display_highlighted_with_checker_text {checker} {
   _copy_mode_copy
   send ""
   sleep 0.1
-  send "echo $checker"
+  send "echo '$checker"
   sleep 0.1
   _tmux_paste
+  send "'"
   send "\r"
 }
 

--- a/test/helpers/expect_copycat_helpers.exp
+++ b/test/helpers/expect_copycat_helpers.exp
@@ -35,6 +35,11 @@ proc tmux_ctrl_t {} {
   sleep 0.7
 }
 
+proc tmux_ctrl_e {} {
+  send ""
+  sleep 0.7
+}
+
 proc search {text} {
   send "/"
   sleep 0.2

--- a/test/helpers/expect_helpers.exp
+++ b/test/helpers/expect_helpers.exp
@@ -34,7 +34,7 @@ proc clear_screen {} {
 }
 
 proc display_text {text} {
-  send "echo $text\r"
+  send "echo '$text'\r"
   sleep 0.1
 }
 

--- a/test/test_email_search.exp
+++ b/test/test_email_search.exp
@@ -1,0 +1,155 @@
+#!/usr/bin/env expect
+
+source "./test/helpers/setup.exp"
+
+# searches at the top of the pane
+#--------------------------------
+display_text "example@example1.com"
+tmux_ctrl_e
+assert_highlighted "example@example1.com" "top of the pane, email"
+
+new_tmux_pane
+display_text "example@example1.com.au"
+tmux_ctrl_e
+assert_highlighted "example@example1.com" "top of the pane, email country code"
+
+# middle of pane searches
+#------------------------
+new_tmux_pane
+create_output
+clear_screen
+display_text "example@example2.com"
+tmux_ctrl_e
+assert_highlighted "example@example2.com" "middle of the pane, email, beginning of the line"
+
+display_text "random example@example3.com"
+tmux_ctrl_e
+assert_highlighted "example@example3.com" "middle of the pane, email, not beginning of the line"
+
+display_text "example@example4.com"
+tmux_ctrl_e
+assert_highlighted "example@example4.com" "middle of the pane, email, beginning of the line"
+
+display_text "some text example@example5.com"
+tmux_ctrl_e
+assert_highlighted "example@example5.com" "middle of the pane, email, not beginning of the line"
+
+create_output
+sleep 0.2
+send " example@example6.com "
+sleep 0.2
+tmux_ctrl_e
+assert_highlighted "example@example6.com" "middle of the pane, email, pane bottom"
+
+# other email structures
+#-----------------------
+new_tmux_pane
+create_output
+clear_screen
+
+display_text "example.person@example.com"
+tmux_ctrl_e
+assert_highlighted "example.person@example.com" "middle of the pane, dotted email"
+
+display_text "example.person+subject@example.com"
+tmux_ctrl_e
+assert_highlighted "example.person+subject@example.com" "middle of the pane, dotted email with plus"
+
+display_text "example@host.example.mueseum"
+tmux_ctrl_e
+assert_highlighted "example@host.example.mueseum" "middle of the pane, new gTLDs, .mueseum"
+
+display_text "example@host.example.party"
+tmux_ctrl_e
+assert_highlighted "example@host.example.party" "middle of the pane, new gTLDs, .party"
+
+display_text "example.\!\#\$%&*+/=?^_`\{|\}~-@example-one.com"
+tmux_ctrl_e
+assert_highlighted "example.\!\#\$%&*+/=?^_`\{|\}~-@example-one.com" "middle of the pane, all special characters"
+
+# emails in html
+#---------------
+new_tmux_pane
+display_text "<a href='mailto:example@example61.com?subject=Test'>asdf</a>"
+tmux_ctrl_e
+assert_highlighted "example@example61.com" "email, subject in html"
+
+# match selection when line contains escaped chars
+#-------------------------------------------------
+new_tmux_pane
+display_text "User ID: example\r\nEmail: example@example7.com\r\n"
+tmux_ctrl_e
+assert_highlighted "example@example7.com" "match selection when line contains escaped chars"
+
+# result navigation
+#------------------
+new_tmux_pane
+display_text "example@example81.com"
+display_text "example@example82.com"
+display_text "example@example83.com"
+tmux_ctrl_e
+# example@example83.com
+next_match
+# example@example83.com
+next_match
+# example@example82.com
+next_match
+# example@example82.com
+next_match
+# example@example81.com
+previous_match
+# example@example82.com
+assert_highlighted "example@example82.com" "result navigation at the top of the pane"
+
+create_output
+display_text "example@example91.com"
+display_text "example@example92.com"
+tmux_ctrl_e
+# example@example92.com
+next_match
+# example@example92.com
+next_match
+# example@example91.com
+previous_match
+# example@example92.com
+assert_highlighted "example@example92.com" "result navigation, middle of the pane"
+
+# 2 matches on the same line
+#---------------------------
+new_tmux_pane
+display_text "example@example101.com example@example102.com"
+tmux_ctrl_e
+assert_highlighted "example@example101.com" "2 matches on the same line, first match"
+
+display_text "example@example111.com example@example112.com"
+tmux_ctrl_e
+next_match
+assert_highlighted "example@example112.com" "2 matches on the same line, second match"
+
+# no match, first and last match
+#-------------------------------
+new_tmux_pane
+tmux_ctrl_e
+assert_on_screen "No results!" "No results is displayed when no results"
+
+display_text "example@example12.com"
+tmux_ctrl_e
+next_match
+next_match
+assert_on_screen "Last match!" "'Last match' is displayed when last match"
+# exit copycat mode
+send ""
+
+new_tmux_pane
+display_text "example@example13.com"
+tmux_ctrl_e
+next_match
+previous_match
+previous_match
+assert_on_screen "First match!" "'First match' is displayed when first match"
+# exit copycat mode
+send ""
+
+# quit
+#-----
+teardown_and_exit

--- a/test/test_file_search.exp
+++ b/test/test_file_search.exp
@@ -66,7 +66,7 @@ next_match
 # /file/1.txt
 previous_match
 # /file/2.txt
-assert_highlighted " /file/2.txt" "result navigation at the top of the pane"
+assert_highlighted "/file/2.txt" "result navigation at the top of the pane"
 
 create_output
 display_text "/file/1.txt"
@@ -79,7 +79,7 @@ next_match
 # /file/1.txt
 previous_match
 # /file/2.txt
-assert_highlighted " /file/2.txt" "result navigation, middle of the pane"
+assert_highlighted "/file/2.txt" "result navigation, middle of the pane"
 
 # 2 matches on the same line
 #---------------------------


### PR DESCRIPTION
Activate the email address search with ``prefix C-e``.  A cursory search of the web shows this key combo doesn't appear common in tmux configurations or other add-ons.

Email address validation is in line with HTML5 http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#valid-e-mail-address, with one small exception of not matching single-quote characters before the @ sign (see background for more below).

The ``display_text`` function in the tests had to change to quote the output being echoed to avoid being processed by the shell.  As a result, one of the existing tests had to be adjusted so it continued working. 

This PR also adds debugging information to the tests readme.

-----

Background on why single-quote character isn't matched:

> Due to quoting in tmux's config, and how the grepping happens, emails with single-quote characters preceding the @ sign (valid emails; though presumably uncommon, given potential confusion!) will not be completely selected.  The match pattern could have been double-quotes rather than single in ``copycat.tmux``, but this would force ``!`` to be escaped, and in this case, the escaping with ``\!`` doesn't get removed.  If this caveat can be fixed by someone with more tmux/plugin knowledge than me, go for it.  As best I can tell, it's either have extremely complicated escaping and no ``!`` with double-quotes or a simpler regex missing the single-quote character.