### PR TITLE
Allow git status to work from any subdirectory.

### DIFF
--- a/scripts/copycat_git_special.sh
+++ b/scripts/copycat_git_special.sh
@@ -7,9 +7,7 @@ PANE_CURRENT_PATH="$1"
 source "$CURRENT_DIR/helpers.sh"
 
 git_status_files() {
-	local git_working_dir="$PANE_CURRENT_PATH"
-	local git_dir="$PANE_CURRENT_PATH/.git"
-	echo "$(git --git-dir="$git_dir" --work-tree="$git_working_dir" status --porcelain)"
+	git -C "$PANE_CURRENT_PATH" status -s
 }
 
 formatted_git_status() {


### PR DESCRIPTION
If the user has status.relativePaths=true (which is the default,) using
"git status" + C-g from anywhere but the repository root failed.

The function "git_status_files()" now returns files in the same format
as displayed by the user's "git status" ensuring successful matches.
