### PR TITLE
Use `command_exists' in reverse_and_create_copycat_file()

### DIFF
--- a/scripts/copycat_generate_results.sh
+++ b/scripts/copycat_generate_results.sh
@@ -17,7 +17,7 @@ reverse_and_create_copycat_file() {
 	local file=$1
 	local copycat_file=$2
 	local grep_pattern=$3
-	(tac 2>/dev/null || tail -r) < "$file" | grep -oniE "$grep_pattern" > "$copycat_file"
+	{ command_exists tac && tac || tail -r; } < "$file" | grep -oniE "$grep_pattern" > "$copycat_file"
 }
 
 delete_old_files() {


### PR DESCRIPTION
This command of `reverse_and_create_copycat_file()` [produces no output](https://asciinema.org/a/2lgfzr5npux2xjynbki88m7u8) on my system[*]:

```
        (tac 2>/dev/null || tail -r) < "$file"
```

Consequently, `prefix + C-f` displays "No results!"

 [*] OS X Yosemite 10.10.5; bash 3.2.57(1)-release)

This patch fixes the problem.
