### PR TITLE
Add *.png binary to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 Vagrantfile eol=lf
 run-tests eol=lf
 test/run-tests-within-vm eol=lf
+*.png binary


### PR DESCRIPTION
core.autocrlf can do some really annoying stupid stuff otherwise, leaving local png files in a permanently modified state and making updating with tpm impossible