### PR TITLE
Custom keytable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,53 +46,18 @@ Searches are case insensitive.<br/>
 
 These start "copycat mode" and jump to first match.
 
-#### Using a custom key table for copycat searches
+#### Using a custom key-table for copycat searches
 
-From `tmux` [manpage](tmux.github.io):
+A special `@copycat_keytable_option` can be set to set all search bindings (except `/`) in a custom key-table, for instance `"cpyct"`. If you don't specify this option, the default key-table remains `"prefix"` (tmux's default key-table), and all works fine, but your keybindings may be more crowded.
 
-    switch-client -T sets the client's key table; the next key from the client will be interpreted from key-table. This may be used to configure multiple prefix keys, or to bind commands to sequences of keys. For example, to make typing ‘abc’ run the list-keys command:
-
-        bind-key -Ttable2 c list-keys
-        bind-key -Ttable1 b switch-client -Ttable2
-        bind-key -Troot   a switch-client -Ttable1
-
-`copycat` can be told to store all its search bindings (except `/`) in a custom `key-table`, for instance `"cpyct"`.
-
-If you don't specify this option, the default `key-table` remains `"prefix"` (tmux's default table), and all works fine, but your keybindings may be more crowded.
-
-In order use a custom `key-table`, the following 2 lines are all you need:
+In order use a custom key-table, the following 2 lines are all you need:
 
     set -g @copycat_keytable_option 'cpyct'
     bind t switch-client -T 'cpyct'
 
 The second line sets the binding for switching to `"cpyct"`: so now `prefix` + `t` + yourbinding.
 
-Example: one can set the following alternative bindings for instance:
-
-    # prefix + t + h searches for git commit SHA1
-    set -g @copycat_hash_search 'h'
-    # prefix + t + d searches for digits
-    set -g @copycat_digit_search 'd'
-    # prefix + t + f searches for filepaths
-    set -g @copycat_file_search 'f'
-    # prefix + t + g searches for files reported by `git status`
-    set -g @copycat_git_special 'g'
-    # prefix + t + i searches for ip addresses
-    set -g @copycat_ip_search 'i'
-    # prefix + t + u searches for url (http[s], ssh, ...)
-    set -g @copycat_url_search 'u'
-    # prefix + t + U searches for uuid
-    set -g @copycat_search_U '\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
-
-then
-
-- `prefix + t + f` - simple *f*ile search
-- `prefix + t + g` - jumping over *g*it status files (best used after `git status` command)
-- `prefix + t + h` - jumping over SHA-1 hashes (best used after `git log` command)
-- `prefix + t + u` - *u*rl search (http, ftp and git urls)
-- `prefix + t + d` - number search (mnemonic d, as digit)
-- `prefix + t + i` - *i*p address search
-- `prefix + t + U` - *U*uid search
+See [customizations.md](docs/customizations.md).
 
 #### "Copycat mode" bindings
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,18 @@ These start "copycat mode" and jump to first match.
 
 #### Using a custom key-table for copycat searches
 
-A special `@copycat_keytable_option` can be set to set all search bindings (except `/`) in a custom key-table, for instance `"cpyct"`. If you don't specify this option, the default key-table remains `"prefix"` (tmux's default key-table), and all works fine, but your keybindings may be more crowded.
+Beginning with tmux `2.1`, we can choose to which key-table our custom key-bindings are assigned (look for the `switch-client -T` option). Before `2.1`, there was no choice for where to place the key-bindings, but now with `2.1` the default key-table is named `prefix`, and we can choose any other key-table name and switch to it (again, this is the new option `switch-client -T custom-key-table-name`).
+
+A special `@copycat_keytable_option` can be set to set all our tmux-copycat search bindings (except `/`) in a custom key-table, for instance `"t"`. If you don't specify this option, the default key-table remains the default `"prefix"` key-table, and all works fine, but your key-bindings may be more crowded.
 
 In order use a custom key-table, the following 2 lines are all you need:
 
-    set -g @copycat_keytable_option 'cpyct'
-    bind t switch-client -T 'cpyct'
+    set -g @copycat_keytable_option 't'
+    bind t switch-client -T 't'
 
-The second line sets the binding for switching to `"cpyct"`: so now `prefix` + `t` + yourbinding.
+The second line sets the binding for switching to `"t"`: so now `prefix` + `t` + yourbinding.
+
+If you have tmux `2.1+`, we use this functionality automatically: all tmux-copycat key-bindings are set to the key-table you defined, and if you have not defined a name as shown above, we choose `t` by default.
 
 See [customizations.md](docs/customizations.md).
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,54 @@ Searches are case insensitive.<br/>
 
 These start "copycat mode" and jump to first match.
 
+#### Using a custom key table for copycat searches
+
+From `tmux` [manpage](tmux.github.io):
+
+    switch-client -T sets the client's key table; the next key from the client will be interpreted from key-table. This may be used to configure multiple prefix keys, or to bind commands to sequences of keys. For example, to make typing ‘abc’ run the list-keys command:
+
+        bind-key -Ttable2 c list-keys
+        bind-key -Ttable1 b switch-client -Ttable2
+        bind-key -Troot   a switch-client -Ttable1
+
+`copycat` can be told to store all its search bindings (except `/`) in a custom `key-table`, for instance `"cpyct"`.
+
+If you don't specify this option, the default `key-table` remains `"prefix"` (tmux's default table), and all works fine, but your keybindings may be more crowded.
+
+In order use a custom `key-table`, the following 2 lines are all you need:
+
+    set -g @copycat_keytable_option 'cpyct'
+    bind t switch-client -T 'cpyct'
+
+The second line sets the binding for switching to `"cpyct"`: so now `prefix` + `t` + yourbinding.
+
+Example: one can set the following alternative bindings for instance:
+
+    # prefix + t + h searches for git commit SHA1
+    set -g @copycat_hash_search 'h'
+    # prefix + t + d searches for digits
+    set -g @copycat_digit_search 'd'
+    # prefix + t + f searches for filepaths
+    set -g @copycat_file_search 'f'
+    # prefix + t + g searches for files reported by `git status`
+    set -g @copycat_git_special 'g'
+    # prefix + t + i searches for ip addresses
+    set -g @copycat_ip_search 'i'
+    # prefix + t + u searches for url (http[s], ssh, ...)
+    set -g @copycat_url_search 'u'
+    # prefix + t + U searches for uuid
+    set -g @copycat_search_U '\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
+
+then
+
+- `prefix + t + f` - simple *f*ile search
+- `prefix + t + g` - jumping over *g*it status files (best used after `git status` command)
+- `prefix + t + h` - jumping over SHA-1 hashes (best used after `git log` command)
+- `prefix + t + u` - *u*rl search (http, ftp and git urls)
+- `prefix + t + d` - number search (mnemonic d, as digit)
+- `prefix + t + i` - *i*p address search
+- `prefix + t + U` - *U*uid search
+
 #### "Copycat mode" bindings
 
 These are enabled when you search with copycat:

--- a/copycat.tmux
+++ b/copycat.tmux
@@ -6,6 +6,15 @@ source "$CURRENT_DIR/scripts/variables.sh"
 source "$CURRENT_DIR/scripts/helpers.sh"
 source "$CURRENT_DIR/scripts/stored_search_helpers.sh"
 
+# this function defines the default key binding table
+set_keytable() {
+	local keytable="$(get_tmux_option "$copycat_keytable_option" "$default_keytable")"
+	local search_value="$(tmux show-options -gqv "$copycat_keytable_option")"
+	if [ -z $search_value ]; then
+		tmux set-option -g "$copycat_keytable_option" "$keytable"
+	fi
+}
+
 # this function defines default stored searches
 set_default_stored_searches() {
 	local file_search="$(get_tmux_option "$copycat_file_search_option" "$default_file_search_key")"
@@ -32,6 +41,7 @@ set_default_stored_searches() {
 }
 
 set_start_bindings() {
+	local keytable="$(tmux show-options -gqv "$copycat_keytable_option")"
 	set_default_stored_searches
 	local stored_search_vars="$(stored_search_vars)"
 	local search_var
@@ -40,7 +50,7 @@ set_start_bindings() {
 	for search_var in $stored_search_vars; do
 		key="$(get_stored_search_key "$search_var")"
 		pattern="$(get_stored_search_pattern "$search_var")"
-		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/copycat_mode_start.sh '$pattern'"
+		tmux bind-key -T "$keytable" "$key" run-shell "$CURRENT_DIR/scripts/copycat_mode_start.sh '$pattern'"
 	done
 }
 
@@ -53,14 +63,16 @@ set_copycat_search_binding() {
 }
 
 set_copycat_git_special_binding() {
+	local keytable="$(tmux show-options -gqv "$copycat_keytable_option")"
 	local key_bindings=$(get_tmux_option "$copycat_git_search_option" "$default_git_search_key")
 	local key
 	for key in $key_bindings; do
-		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/copycat_git_special.sh #{pane_current_path}"
+		tmux bind-key -T "$keytable" "$key" run-shell "$CURRENT_DIR/scripts/copycat_git_special.sh #{pane_current_path}"
 	done
 }
 
 main() {
+	set_keytable
 	set_start_bindings
 	set_copycat_search_binding
 	set_copycat_git_special_binding

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -32,14 +32,14 @@ From `tmux` [manpage](tmux.github.io):
         bind-key -Ttable1 b switch-client -Ttable2
         bind-key -Troot   a switch-client -Ttable1
 
-`copycat` can be told to store all its search bindings (except `/`) in a custom key-table, for instance `"cpyct"`. If you don't specify this option, the default key-table remains `"prefix"` (tmux's default key-table), and all works fine, but your keybindings may be more crowded.
+`copycat` can be told to store all its search bindings (except `/`) in a custom key-table, for instance `"t"`. If you don't specify this option, the default key-table is now `"t"`, so you should add a binding to switch to this table, but your keybindings will be less crowded.
 
 In order use a custom key-table, the following 2 lines are all you need:
 
-    set -g @copycat_keytable_option 'cpyct'
-    bind t switch-client -T 'cpyct'
+    set -g @copycat_keytable_option 't'
+    bind t switch-client -T 't'
 
-The second line sets the binding for switching to `"cpyct"`: so now `prefix` + `t` + yourbinding.
+The second line sets the binding for switching to `"t"`: so now `prefix` + `t` + yourbinding.
 
 Example: one can set the following alternative bindings for instance:
 

--- a/docs/customizations.md
+++ b/docs/customizations.md
@@ -22,5 +22,48 @@ Options for predefined searches:
 - `@copycat_hash_search` (default `M-h`) SHA-1 hash search
 - `@copycat_ip_search` (default `M-i`) IP address search
 
-Example: to remap default file search to use `C-t` put
-`set -g @copycat_file_search 'C-t'` in `.tmux.conf`.
+## Custom key-table
+
+From `tmux` [manpage](tmux.github.io):
+
+    switch-client -T sets the client's key table; the next key from the client will be interpreted from key-table. This may be used to configure multiple prefix keys, or to bind commands to sequences of keys. For example, to make typing ‘abc’ run the list-keys command:
+
+        bind-key -Ttable2 c list-keys
+        bind-key -Ttable1 b switch-client -Ttable2
+        bind-key -Troot   a switch-client -Ttable1
+
+`copycat` can be told to store all its search bindings (except `/`) in a custom key-table, for instance `"cpyct"`. If you don't specify this option, the default key-table remains `"prefix"` (tmux's default key-table), and all works fine, but your keybindings may be more crowded.
+
+In order use a custom key-table, the following 2 lines are all you need:
+
+    set -g @copycat_keytable_option 'cpyct'
+    bind t switch-client -T 'cpyct'
+
+The second line sets the binding for switching to `"cpyct"`: so now `prefix` + `t` + yourbinding.
+
+Example: one can set the following alternative bindings for instance:
+
+    # prefix + t + h searches for git commit SHA1
+    set -g @copycat_hash_search 'h'
+    # prefix + t + d searches for digits
+    set -g @copycat_digit_search 'd'
+    # prefix + t + f searches for filepaths
+    set -g @copycat_file_search 'f'
+    # prefix + t + g searches for files reported by `git status`
+    set -g @copycat_git_special 'g'
+    # prefix + t + i searches for ip addresses
+    set -g @copycat_ip_search 'i'
+    # prefix + t + u searches for url (http[s], ssh, ...)
+    set -g @copycat_url_search 'u'
+    # prefix + t + U searches for uuid
+    set -g @copycat_search_U '\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
+
+then
+
+- `prefix + t + f` - simple *f*ile search
+- `prefix + t + g` - jumping over *g*it status files (best used after `git status` command)
+- `prefix + t + h` - jumping over SHA-1 hashes (best used after `git log` command)
+- `prefix + t + u` - *u*rl search (http, ftp and git urls)
+- `prefix + t + d` - number search (mnemonic d, as digit)
+- `prefix + t + i` - *i*p address search
+- `prefix + t + U` - *U*uid search

--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -16,15 +16,20 @@ extend_key() {
 	# 3. `true` command ensures an exit status 0 is returned. This ensures a
 	#	 user never gets an error msg - even if the script file from step 2 is
 	#	 deleted.
-	tmux bind-key -n "$key" run-shell "tmux send-keys '$key'; $script; true"
+	tmux bind-key -T copy-mode    "$key" run-shell "$script"
+	tmux bind-key -T copy-mode-vi "$key" run-shell "$script"
+	# tmux bind-key -n "$key" run-shell "tmux send-keys '$key'; $script; true"
 }
 
 copycat_cancel_bindings() {
 	# keys that quit copy mode are enhanced to quit copycat mode as well.
-	local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
+	# local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
+	local cancel_mode_bindings='C-c Enter q'
 	local key
 	for key in $cancel_mode_bindings; do
-		extend_key "$key" "$CURRENT_DIR/copycat_mode_quit.sh"
+		tmux bind-key -T copy-mode    "$key" run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
+		tmux bind-key -T copy-mode-vi "$key" run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
+		# extend_key "$key" "$CURRENT_DIR/copycat_mode_quit.sh"
 	done
 }
 

--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -31,6 +31,22 @@ copycat_cancel_bindings() {
 		tmux bind-key -T copy-mode-vi "$key" run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
 		# extend_key "$key" "$CURRENT_DIR/copycat_mode_quit.sh"
 	done
+
+	# rebind original tmux yank
+	local yank_key='y'
+	local put_key='Y'
+	local yank_put_key='M-y'
+	local yank_wo_newline_key='!'
+	local copy_command='reattach-to-user-namespace pbcopy'
+	local copy_wo_newline_command="tr -d '\\n' | $copy_command"
+	tmux unbind-key -T copy-mode-vi "$yank_key"
+	tmux unbind-key -T copy-mode-vi "$put_key"
+	tmux unbind-key -T copy-mode-vi "$yank_put_key"
+	tmux unbind-key -T copy-mode-vi "$yank_wo_newline_key"
+	tmux   bind-key -T copy-mode-vi "$yank_key"            send-keys -X copy-pipe "$copy_command" \\\; run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
+	tmux   bind-key -T copy-mode-vi "$put_key"             send-keys -X copy-pipe "tmux paste-buffer" \\\; run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
+	tmux   bind-key -T copy-mode-vi "$yank_put_key"        send-keys -X copy-pipe "$copy_command; tmux paste-buffer" \\\; run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
+	tmux   bind-key -T copy-mode-vi "$yank_wo_newline_key" send-keys -X copy-pipe "$copy_wo_newline_command" \\\; run-shell "$CURRENT_DIR/copycat_mode_quit.sh" \\\; send-keys -X cancel
 }
 
 copycat_mode_bindings() {

--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -15,6 +15,23 @@ unbind_cancel_bindings() {
 		tmux   bind-key -T copy-mode-vi "$key" send-keys -X cancel
 		# tmux unbind-key -n "$key"
 	done
+
+	# rebind original tmux yank
+	local yank_key='y'
+	local put_key='Y'
+	local yank_put_key='M-y'
+	local yank_wo_newline_key='!'
+	local copy_command='reattach-to-user-namespace pbcopy'
+	local copy_wo_newline_command="tr -d '\\n' | $copy_command"
+	tmux unbind-key -T copy-mode-vi "$yank_key"
+	tmux unbind-key -T copy-mode-vi "$put_key"
+	tmux unbind-key -T copy-mode-vi "$yank_put_key"
+	tmux unbind-key -T copy-mode-vi "$yank_wo_newline_key"
+	tmux   bind-key -T copy-mode-vi "$yank_key"            send-keys -X copy-pipe-and-cancel "$copy_command"
+	tmux   bind-key -T copy-mode-vi "$put_key"             send-keys -X copy-pipe-and-cancel "tmux paste-buffer"
+	tmux   bind-key -T copy-mode-vi "$yank_put_key"        send-keys -X copy-pipe-and-cancel "$copy_command; tmux paste-buffer"
+	tmux   bind-key -T copy-mode-vi "$yank_wo_newline_key" send-keys -X copy-pipe-and-cancel "$copy_wo_newline_command"
+
 }
 
 unbind_prev_next_bindings() {

--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -5,16 +5,30 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 
 unbind_cancel_bindings() {
-	local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
+	# local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
+	local cancel_mode_bindings='C-c Enter q'
 	local key
 	for key in $cancel_mode_bindings; do
-		tmux unbind-key -n "$key"
+		tmux unbind-key -T copy-mode    "$key"
+		tmux   bind-key -T copy-mode    "$key" send-keys -X cancel
+		tmux unbind-key -T copy-mode-vi "$key"
+		tmux   bind-key -T copy-mode-vi "$key" send-keys -X cancel
+		# tmux unbind-key -n "$key"
 	done
 }
 
 unbind_prev_next_bindings() {
-	tmux unbind-key -n "$(copycat_next_key)"
-	tmux unbind-key -n "$(copycat_prev_key)"
+	tmux unbind-key -T copy-mode    "$(copycat_next_key)"
+	# tmux   bind-key -T copy-mode    "$(copycat_next_key)" send-keys -X search-again
+	tmux unbind-key -T copy-mode    "$(copycat_prev_key)"
+	# tmux   bind-key -T copy-mode    "$(copycat_prev_key)" send-keys -X search-reverse
+
+	tmux unbind-key -T copy-mode-vi "$(copycat_next_key)"
+	# tmux   bind-key -T copy-mode-vi "$(copycat_next_key)" send-keys -X search-again
+	tmux unbind-key -T copy-mode-vi "$(copycat_prev_key)"
+	# tmux   bind-key -T copy-mode-vi "$(copycat_prev_key)" send-keys -X search-reverse
+	# tmux unbind-key -n "$(copycat_next_key)"
+	# tmux unbind-key -n "$(copycat_prev_key)"
 }
 
 unbind_all_bindings() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -150,9 +150,11 @@ copycat_prev_key() {
 
 # function expected output: 'C-c Enter q'
 copycat_quit_copy_mode_keys() {
-	local commands_that_quit_copy_mode="cancel\|copy-selection\|copy-pipe"
-	local copy_mode="$(tmux_copy_mode)-copy"
-	tmux list-keys -t "$copy_mode" |
+	# local commands_that_quit_copy_mode="cancel\|copy-selection\|copy-pipe"
+	# local copy_mode="copy-mode-$(tmux_copy_mode)"
+	# tmux list-keys -T "$copy_mode" |
+	local commands_that_quit_copy_mode="cancel"
+  	tmux list-keys -T copy-mode-vi |
 		\grep "$commands_that_quit_copy_mode" |
 		$AWK_CMD '{ print $4}' |
 		sort -u |

--- a/scripts/keytable_helpers.sh
+++ b/scripts/keytable_helpers.sh
@@ -1,0 +1,14 @@
+VERSION_WITH_KEYTABLE_SUPPORT="2.1"
+
+keytable_tmux_version_ok() {
+	$CURRENT_DIR/scripts/check_tmux_version.sh "$VERSION_WITH_KEYTABLE_SUPPORT"
+}
+
+get_keytable_arguments() {
+	local keytable="$(get_tmux_option "$copycat_keytable_option" "$default_keytable")"
+	if keytable_tmux_version_ok; then
+		echo "-T $keytable"
+	else
+		echo ""
+	fi
+}

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -26,5 +26,5 @@ default_ip_search_key="M-i"
 copycat_ip_search_option="@copycat_ip_search"
 
 # bind table variable prefix
-default_keytable="prefix"
+default_keytable="t"
 copycat_keytable_option="@copycat_keytable"

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -24,3 +24,7 @@ copycat_hash_search_option="@copycat_hash_search"
 
 default_ip_search_key="M-i"
 copycat_ip_search_option="@copycat_ip_search"
+
+# bind table variable prefix
+default_keytable="prefix"
+copycat_keytable_option="@copycat_keytable"


### PR DESCRIPTION
Hi,

Here is a new `@copycat_keytable_option` option that, if set, uses a custom keytable for all searches except `/` (this one is too useful to be altered). If this option is not set, the default `prefix` keytable is used.

With this, my shortcuts are less crowded and I find them easier to remember.

I have added instructions in the [README.md](https://github.com/tmux-plugins/tmux-copycat/blob/master/README.md) and [customisations.md](https://github.com/tmux-plugins/tmux-copycat/blob/master/docs/customizations.md)

Regards
