### PR TITLE
make working directory only be accessible by user

### DIFF
--- a/scripts/copycat_generate_results.sh
+++ b/scripts/copycat_generate_results.sh
@@ -31,6 +31,7 @@ generate_copycat_file() {
 	local scrollback_filename="$(get_scrollback_filename)"
 	local copycat_filename="$(get_copycat_filename)"
 	mkdir -p "$(_get_tmp_dir)"
+	chmod 0700 "$(_get_tmp_dir)"
 	capture_pane "$scrollback_filename"
 	reverse_and_create_copycat_file "$scrollback_filename" "$copycat_filename" "$grep_pattern"
 }


### PR DESCRIPTION
This makes /tmp/tmux-NNNN-copycat/ only accessible by the current user
of the tmux session. While not important on single user systems, this
could be a concern on multi-user servers, where using tmux-copycat would
capture the scrollback text of the current terminal to a file that could
be read by other users, especially if you don't have a strict umask.
