### PR TITLE
Improve quitting copy mode

### DIFF
--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -27,10 +27,10 @@ main() {
 		reset_copycat_position
 		unset_copycat_mode
 		copycat_decrease_counter
-		# removing all bindings only if no panes are in copycat mode
-		if copycat_counter_zero; then
-			unbind_all_bindings
-		fi
+	fi
+	# removing all bindings only if no panes are in copycat mode
+	if copycat_counter_zero; then
+		unbind_all_bindings
 	fi
 }
 main

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -150,7 +150,7 @@ copycat_prev_key() {
 
 # function expected output: 'C-c Enter q'
 copycat_quit_copy_mode_keys() {
-	local commands_that_quit_copy_mode="cancel\|copy-selection\|copy-pipe"
+	local commands_that_quit_copy_mode="cancel\|copy-selection\|copy-pipe\|append-selection\|copy-end-of-line"
 	local copy_mode="$(tmux_copy_mode)-copy"
 	tmux list-keys -t "$copy_mode" |
 		\grep "$commands_that_quit_copy_mode" |


### PR DESCRIPTION
Add more commands that exit copy mode (append-selection and copy-end-of-line) and check the counter to unbind keys even if not currently in copy mode. This should help with https://github.com/tmux-plugins/tmux-copycat/issues/99.