### PR TITLE
Standardize all predefined searches to use Ctrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Searches are case insensitive.<br/>
 
 - `prefix + ctrl-f` - simple *f*ile search
 - `prefix + ctrl-g` - jumping over *g*it status files (best used after `git status` command)
-- `prefix + alt-h` - jumping over SHA-1 hashes (best used after `git log` command)
+- `prefix + ctrl-a` - jumping over SH*A*-1 h*a*shes (best used after `git log` command)
 - `prefix + ctrl-u` - *u*rl search (http, ftp and git urls)
 - `prefix + ctrl-d` - number search (mnemonic d, as digit)
-- `prefix + alt-i` - *i*p address search
+- `prefix + ctrl-i` - *i*p address search
 
 These start "copycat mode" and jump to first match.
 

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -19,8 +19,8 @@ copycat_url_search_option="@copycat_url_search"
 default_digit_search_key="C-d"
 copycat_digit_search_option="@copycat_digit_search"
 
-default_hash_search_key="M-h"
+default_hash_search_key="C-a"
 copycat_hash_search_option="@copycat_hash_search"
 
-default_ip_search_key="M-i"
+default_ip_search_key="C-i"
 copycat_ip_search_option="@copycat_ip_search"

--- a/test/helpers/expect_copycat_helpers.exp
+++ b/test/helpers/expect_copycat_helpers.exp
@@ -25,8 +25,8 @@ proc tmux_ctrl_g {} {
   sleep 0.7
 }
 
-proc tmux_alt_h {} {
-  send "h"
+proc tmux_ctrl_a {} {
+  send ""
   sleep 0.7
 }
 

--- a/test/test_git_hash_search.exp
+++ b/test/test_git_hash_search.exp
@@ -7,13 +7,13 @@ enter_test_git_repo
 # Match regular SHA-1 hashes
 #---------------------------
 git_log_reverse
-tmux_alt_h
+tmux_ctrl_a
 assert_highlighted "935929c4c7265666e41e727f97a87d1af00a8b40" "match regular SHA-1 hashes"
 
 #Match shortened SHA-1 hashes
 #----------------------------
 git_log_reverse_short
-tmux_alt_h
+tmux_ctrl_a
 assert_highlighted "935929c" "match shortened SHA-1 hashes"
 
 # quit


### PR DESCRIPTION
Reasons:
- The Alt key is inconvenient/confusing for most OS X users. Alt is not enabled by default so it needs to be specifically remapped in a terminal application.
- Consistency is better. It's easier to remember the search keys if they all use Ctrl.

Why the Alt mappings exist:
- I assume there was a good reason to use Alt when the IP address search was added, but the [commit message](https://github.com/tmux-plugins/tmux-copycat/commit/e3d346400b1cc5df75f901df9a5d2c3b1bfec6bd) doesn't mention what it was.
- The SHA-1 search was originally changed from Ctrl to Alt because `prefix + C-h` [conflicts with tmux-pain-control](https://github.com/tmux-plugins/tmux-copycat/pull/73#issuecomment-105932793). `C-s` doesn't work either because it sends the `XOFF` signal, so changing this will require an awkward letter. I went with "a" because it's the vowel in both "SHA" and "hash".

Backwards compatibility with the old mappings should be added as well, but I'd like to hear your thoughts on this PR before writing more code.