### PR TITLE
BUG: keybinding values undergo globbing, may break mappings

### DIFF
--- a/copycat.tmux
+++ b/copycat.tmux
@@ -45,17 +45,19 @@ set_start_bindings() {
 }
 
 set_copycat_search_binding() {
-	local key_bindings=$(get_tmux_option "$copycat_search_option" "$default_copycat_search_key")
+	local key_bindings
+	read -r -d '' -a key_bindings <<<"$(get_tmux_option "$copycat_search_option" "$default_copycat_search_key")"
 	local key
-	for key in $key_bindings; do
+	for key in "${key_bindings[@]}"; do
 		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/copycat_search.sh"
 	done
 }
 
 set_copycat_git_special_binding() {
-	local key_bindings=$(get_tmux_option "$copycat_git_search_option" "$default_git_search_key")
+	local key_bindings
+	read -r -d '' -a key_bindings <<<"$(get_tmux_option "$copycat_git_search_option" "$default_git_search_key")"
 	local key
-	for key in $key_bindings; do
+	for key in "${key_bindings[@]}"; do
 		tmux bind-key "$key" run-shell "$CURRENT_DIR/scripts/copycat_git_special.sh #{pane_current_path}"
 	done
 }


### PR DESCRIPTION
I have configured the copycat search key to '?' (`set -g @copycat_search '?'` in `.tmux.conf`), and all of a sudden the mapping was assigned to _prefix + 6_ instead of _prefix + ?_. Turned out I had a file `~/6`, and the `?` mistakenly is expanded to `6`.
The problem is the unquoted variable reference "`for key in $key_bindings`". As we need the word splitting for the (undocumented?) feature of allowing multiple key mappings, it cannot be quoted.
As a fix, use `read` with a here-string to perform word splitting in an array variable, and then iterate over the array elements.
