### PR TITLE
Fix tmux-plugins/tmux-copycat#121

### DIFF
--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -19,7 +19,7 @@ unbind_prev_next_bindings() {
 
 unbind_all_bindings() {
 	grep -v copycat </tmp/copycat_$(whoami)_recover_keys | while read key_cmd; do
-		tmux $key_cmd
+		sh -c "tmux $key_cmd"
 	done < /dev/stdin
 	rm /tmp/copycat_$(whoami)_recover_keys
 }


### PR DESCRIPTION
The issue was caused by incorrect parameter expansion.

Copycat saves the old bindings inside
/tmp/copycat_$(whoami)_recover_keys as they were provided on the command
line, e.g.

    $ cat /tmp/copycat_$(whoami)_recover_keys | grep clipboard
    bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"

When tmux-copycat restores the config it reads each line of that
temporary file into `key_cmd` and runs `tmux $key_cmd`. Now, when the
shell expands `$key_cmd` it expands `"xclip`, `-selection`, `clipboard"`
into separate words. `tmux $key_cmd` runs effectively as:

    tmux bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "\"xclip" -selection "clipboard\""

Which is not what we want.

In order to fix this bug, this commit makes sure that a proper shell
expansion happens by using `sh -c`.