### PR TITLE
Search for nrepl urls too

### DIFF
--- a/copycat.tmux
+++ b/copycat.tmux
@@ -15,7 +15,7 @@ set_default_stored_searches() {
 	local ip_search="$(get_tmux_option "$copycat_ip_search_option" "$default_ip_search_key")"
 
 	if stored_search_not_defined "$url_search"; then
-		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${url_search}" "(https?://|git@|git://|ssh://|ftp://|file:///)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*"
+		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${url_search}" "(https?://|git@|git://|ssh://|ftp://|file:///|nrepl://)[[:alnum:]?=%/_.:,;~@!#$&()*+-]*"
 	fi
 	if stored_search_not_defined "$file_search"; then
 		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${file_search}" "(^|^\.|[[:space:]]|[[:space:]]\.|[[:space:]]\.\.|^\.\.)[[:alnum:]~_-]*/[][[:alnum:]_.#$%&+=/@-]*"

--- a/test/test_url_search.exp
+++ b/test/test_url_search.exp
@@ -62,6 +62,10 @@ display_text "file:///foo/bar/file.txt"
 tmux_ctrl_u
 assert_highlighted "file:///foo/bar/file.txt" "middle of the pane, file url"
 
+display_text "nrepl://127.0.0.1:40252"
+tmux_ctrl_u
+assert_highlighted "nrepl://127.0.0.1:40252" "middle of the pane, nrepl url"
+
 # urls with parameters
 #---------------------
 new_tmux_pane


### PR DESCRIPTION
This is helpful when firing up a Clojure repl which outputs a nrepl url
which we can copy and connect to from editors.