### PR TITLE
Also match sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Searches are case insensitive.<br/>
 
 - `prefix + ctrl-f` - simple *f*ile search
 - `prefix + ctrl-g` - jumping over *g*it status files (best used after `git status` command)
-- `prefix + alt-h` - jumping over SHA-1 hashes (best used after `git log` command)
+- `prefix + alt-h` - jumping over SHA-1/SHA-256 hashes (best used after `git log` command)
 - `prefix + ctrl-u` - *u*rl search (http, ftp and git urls)
 - `prefix + ctrl-d` - number search (mnemonic d, as digit)
 - `prefix + alt-i` - *i*p address search

--- a/copycat.tmux
+++ b/copycat.tmux
@@ -24,7 +24,7 @@ set_default_stored_searches() {
 		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${digit_search}" "[[:digit:]]+"
 	fi
 	if stored_search_not_defined "$hash_search"; then
-		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${hash_search}" "\b[0-9a-f]{7,40}\b"
+		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${hash_search}" "\b([0-9a-f]{7,40}|[[:alnum:]]{52}|[0-9a-f]{62})\b"
 	fi
 	if stored_search_not_defined "$ip_search"; then
 		tmux set-option -g "${COPYCAT_VAR_PREFIX}_${ip_search}" "[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}\.[[:digit:]]{1,3}"


### PR DESCRIPTION
This regex detect both the hex and base32 format

This is useful because:

- Sha1 is insecure and going to be replaced by sha256 in git.
- As package maintainer we often use sha256 to verify packages.
- docker and other container engines uses sha256 for container images