### PR TITLE
Use TMPDIR, if available, for storing recover_keys file.

### DIFF
--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -30,7 +30,7 @@ extend_key() {
 	fi
 	# We save the previous mapping to a file in order to be able to recover
 	# the previous mapping when we unbind
-	tmux list-keys -T $(tmux_copy_mode_string) | $AWK_CMD '$4 == "'$key'"' >> /tmp/copycat_$(whoami)_recover_keys
+	tmux list-keys -T $(tmux_copy_mode_string) | $AWK_CMD '$4 == "'$key'"' >> "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"
 	tmux bind-key -T $(tmux_copy_mode_string) "$key" run-shell "tmux $cmd; $script; true"
 }
 

--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -18,10 +18,10 @@ unbind_prev_next_bindings() {
 }
 
 unbind_all_bindings() {
-	grep -v copycat </tmp/copycat_$(whoami)_recover_keys | while read key_cmd; do
+	grep -v copycat <"${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys" | while read key_cmd; do
 		sh -c "tmux $key_cmd"
 	done < /dev/stdin
-	rm /tmp/copycat_$(whoami)_recover_keys
+	rm "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"
 }
 
 main() {


### PR DESCRIPTION
Please include this small patch. It ensures that $TMPDIR is used to store the copycat_<user>_recover_keys file. Falls back to /tmp if $TMPDIR is not set.
Thank you.