### PR TITLE
Fix unwanted changes to other keybindings

### DIFF
--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -18,7 +18,7 @@ unbind_prev_next_bindings() {
 }
 
 unbind_all_bindings() {
-	grep -v copycat <"${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys" | while read key_cmd; do
+	grep -v copycat <"${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys" | while read -r key_cmd; do
 		sh -c "tmux $key_cmd"
 	done < /dev/stdin
 	rm "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"


### PR DESCRIPTION
This is a tmux-open keybinding just after (re)loading `tmux.conf`:

```
> tmux list-keys

bind-key  -T copy-mode-vi o  send-keys -X copy-pipe-and-cancel "xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; xdg-open \"{}\" > /dev/null'"
```

Then you execute `prefix<c-u>` once, it will work, but checking `tmux list-keys` again, the tmux-open keybinding has changed:

```
> tmux list-keys

bind-key  -T copy-mode-vi o  send-keys -X copy-pipe-and-cancel "xargs -I {} tmux run-shell -b 'cd #{pane_current_path}; xdg-open {} > /dev/null'"
```

`xdg-open \"{}\" ` got replaced by `xdg-open {} `, and tmux-open won't work for URLs containing `&` and other special chars anymore until reload. There may be a vulnerability here too (because of `&some_bad_command`).

Migrated from: https://github.com/tmux-plugins/tmux-open/issues/37.