### PR TITLE
Allow searches beginning with `--`

### DIFF
--- a/scripts/copycat_generate_results.sh
+++ b/scripts/copycat_generate_results.sh
@@ -17,7 +17,7 @@ reverse_and_create_copycat_file() {
 	local file=$1
 	local copycat_file=$2
 	local grep_pattern=$3
-	(tac 2>/dev/null || tail -r) < "$file" | grep -oniE "$grep_pattern" > "$copycat_file"
+	(tac 2>/dev/null || tail -r) < "$file" | grep -oniE -- "$grep_pattern" > "$copycat_file"
 }
 
 delete_old_files() {


### PR DESCRIPTION
Without telling grep that we've finished providing arguments, the search query will be interpreted as an argument to grep.