### PR TITLE
Improve copycat mode startup time

### DIFF
--- a/copycat.tmux
+++ b/copycat.tmux
@@ -62,9 +62,14 @@ set_copycat_git_special_binding() {
 	done
 }
 
+set_copycat_mode_bindings() {
+	"$CURRENT_DIR/scripts/copycat_mode_bindings.sh"
+}
+
 main() {
 	set_start_bindings
 	set_copycat_search_binding
 	set_copycat_git_special_binding
+	set_copycat_mode_bindings
 }
 main

--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -24,16 +24,16 @@ extend_key() {
 	#    a user never gets an error msg - even if the script file from step 2
 	#    is deleted.
 	tmux list-keys -T "$copy_mode" |
-	"$AWK_CMD" '
+	"$AWK_CMD" -v mode="$copy_mode" -v key="$key" -v script="$script" '
 		/copycat/ { next }
-		$3 == "'"$copy_mode"'" && $4 == "'"$key"'" {
+		$3 == mode && $4 == key {
 			$1=""
 			$2=""
 			$3=""
 			$4=""
-			gsub(";", "\\;", $0)
 			cmd=$0
-			system("tmux bind-key -T '"$copy_mode"' '"$key"' run-shell \"tmux " cmd "; '"$script"'; true\"")
+			gsub(/["\\]/, "\\\\&", cmd)
+			system("tmux bind-key -T " mode " " key " run-shell \"tmux " cmd "; " script "; true\"")
 		}'
 }
 

--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -14,24 +14,27 @@ fi
 extend_key() {
 	local key="$1"
 	local script="$2"
-	local cmd
+	local copy_mode
+	copy_mode=$(tmux_copy_mode_string)
 
-	# 1. 'cmd' or 'key' is sent to tmux. This ensures the default key action is done.
+	# 1. The default command for 'key' is sent to tmux. This ensures the
+	#    default key action is done.
 	# 2. Script is executed.
-	# 3. `true` command ensures an exit status 0 is returned. This ensures a
-	#	 user never gets an error msg - even if the script file from step 2 is
-	#	 deleted.
-	# We fetch the current behavior of the 'key' mapping in
-	# variable 'cmd'
-	cmd=$(tmux list-keys -T $(tmux_copy_mode_string) | $AWK_CMD '$4 == "'$key'"' | $AWK_CMD '{ $1=""; $2=""; $3=""; $4=""; sub("  ", " "); print }')
-	# If 'cmd' is already a copycat command, we do nothing
-	if echo "$cmd" | grep -q copycat; then
-		return
-	fi
-	# We save the previous mapping to a file in order to be able to recover
-	# the previous mapping when we unbind
-	tmux list-keys -T $(tmux_copy_mode_string) | $AWK_CMD '$4 == "'$key'"' >> "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"
-	tmux bind-key -T $(tmux_copy_mode_string) "$key" run-shell "tmux $cmd; $script; true"
+	# 3. `true` command ensures an exit status 0 is returned. This ensures
+	#    a user never gets an error msg - even if the script file from step 2
+	#    is deleted.
+	tmux list-keys -T "$copy_mode" |
+	"$AWK_CMD" '
+		/copycat/ { next }
+		$3 == "'"$copy_mode"'" && $4 == "'"$key"'" {
+			$1=""
+			$2=""
+			$3=""
+			$4=""
+			gsub(";", "\\;", $0)
+			cmd=$0
+			system("tmux bind-key -T '"$copy_mode"' '"$key"' run-shell \"tmux " cmd "; '"$script"'; true\"")
+		}'
 }
 
 copycat_cancel_bindings() {

--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -4,35 +4,11 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/helpers.sh"
 
-unbind_cancel_bindings() {
-	local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
-	local key
-	for key in $cancel_mode_bindings; do
-		tmux unbind-key -n "$key"
-	done
-}
-
-unbind_prev_next_bindings() {
-	tmux unbind-key -n "$(copycat_next_key)"
-	tmux unbind-key -n "$(copycat_prev_key)"
-}
-
-unbind_all_bindings() {
-	grep -v copycat <"${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys" | while read -r key_cmd; do
-		sh -c "tmux $key_cmd"
-	done < /dev/stdin
-	rm "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"
-}
-
 main() {
 	if in_copycat_mode; then
 		reset_copycat_position
 		unset_copycat_mode
 		copycat_decrease_counter
-		# removing all bindings only if no panes are in copycat mode
-		if copycat_counter_zero; then
-			unbind_all_bindings
-		fi
 	fi
 }
 main

--- a/scripts/copycat_mode_start.sh
+++ b/scripts/copycat_mode_start.sh
@@ -14,7 +14,6 @@ main() {
 	local pattern="$1"
 	if supported_tmux_version_ok; then
 		$CURRENT_DIR/copycat_generate_results.sh "$pattern" # will `exit 0` if no results
-		$CURRENT_DIR/copycat_mode_bindings.sh
 		$CURRENT_DIR/copycat_jump.sh 'next'
 	fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -42,11 +42,11 @@ tmux_copy_mode() {
 }
 
 tmux_copy_mode_string() {
-    if [ $(tmux_copy_mode) == 'vi' ]; then
-	echo copy-mode-vi
-    else
-	echo copy-mode
-    fi
+	if [ $(tmux_copy_mode) == 'vi' ]; then
+		echo copy-mode-vi
+	else
+		echo copy-mode
+	fi
 }
 
 # === copycat mode specific helpers ===


### PR DESCRIPTION
Set the copycat mode key bindings once at the very beginning and streamline the process of setting those bindings (use a single pass-through with `awk` instead of iterating over the list of keybindings every time).

This has a significant impact on the startup time of copycat mode since it does not have to rebind they keys every time copycat mode is started. We can get away with this since all of the copycat scripts check to make sure we are in copycat mode before they do anything, so even if they are executed when _not_ in copycat mode, they are basically a no-op.