### PR TITLE
Revert "Improve performance by binding copycat keys just once"

### DIFF
--- a/copycat.tmux
+++ b/copycat.tmux
@@ -62,14 +62,9 @@ set_copycat_git_special_binding() {
 	done
 }
 
-set_copycat_mode_bindings() {
-	"$CURRENT_DIR/scripts/copycat_mode_bindings.sh"
-}
-
 main() {
 	set_start_bindings
 	set_copycat_search_binding
 	set_copycat_git_special_binding
-	set_copycat_mode_bindings
 }
 main

--- a/scripts/copycat_mode_bindings.sh
+++ b/scripts/copycat_mode_bindings.sh
@@ -14,11 +14,9 @@ fi
 extend_key() {
 	local key="$1"
 	local script="$2"
-	local copy_mode
-	copy_mode=$(tmux_copy_mode_string)
+	local cmd
 
-	# 1. The default command for 'key' is sent to tmux. This ensures the
-	#    default key action is done.
+	# 1. 'cmd' or 'key' is sent to tmux. This ensures the default key action is done.
 	# 2. Script is executed.
 	# 3. `true` command ensures an exit status 0 is returned. This ensures
 	#    a user never gets an error msg - even if the script file from step 2

--- a/scripts/copycat_mode_quit.sh
+++ b/scripts/copycat_mode_quit.sh
@@ -4,11 +4,35 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$CURRENT_DIR/helpers.sh"
 
+unbind_cancel_bindings() {
+	local cancel_mode_bindings=$(copycat_quit_copy_mode_keys)
+	local key
+	for key in $cancel_mode_bindings; do
+		tmux unbind-key -n "$key"
+	done
+}
+
+unbind_prev_next_bindings() {
+	tmux unbind-key -n "$(copycat_next_key)"
+	tmux unbind-key -n "$(copycat_prev_key)"
+}
+
+unbind_all_bindings() {
+	grep -v copycat <"${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys" | while read -r key_cmd; do
+		sh -c "tmux $key_cmd"
+	done < /dev/stdin
+	rm "${TMPDIR:-/tmp}/copycat_$(whoami)_recover_keys"
+}
+
 main() {
 	if in_copycat_mode; then
 		reset_copycat_position
 		unset_copycat_mode
 		copycat_decrease_counter
+		# removing all bindings only if no panes are in copycat mode
+		if copycat_counter_zero; then
+			unbind_all_bindings
+		fi
 	fi
 }
 main

--- a/scripts/copycat_mode_start.sh
+++ b/scripts/copycat_mode_start.sh
@@ -14,6 +14,7 @@ main() {
 	local pattern="$1"
 	if supported_tmux_version_ok; then
 		$CURRENT_DIR/copycat_generate_results.sh "$pattern" # will `exit 0` if no results
+		$CURRENT_DIR/copycat_mode_bindings.sh
 		$CURRENT_DIR/copycat_jump.sh 'next'
 	fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -42,11 +42,11 @@ tmux_copy_mode() {
 }
 
 tmux_copy_mode_string() {
-	if [ $(tmux_copy_mode) == 'vi' ]; then
-		echo copy-mode-vi
-	else
-		echo copy-mode
-	fi
+    if [ $(tmux_copy_mode) == 'vi' ]; then
+	echo copy-mode-vi
+    else
+	echo copy-mode
+    fi
 }
 
 # === copycat mode specific helpers ===


### PR DESCRIPTION
This reverts commit 6bcd4dc4eb3e9f8106aa03f422b54e6dd19f4044. It broke the once
fixed issue with Yank (https://github.com/tmux-plugins/tmux-copycat/issues/121),
causing a regression. To ensure this was the problematic commit, I checked out
its parent (ca3d52dc48bee27af5e5f55035cf82e188011e94) and it's working fine
there, so I suggest we revert the broken commit.

In summary (check the link above for details), this commit breaks Tmux scrolling
completely, and after getting into scrolling no keys will work, so you can't
leave scrolling. Only workaround I found was killing `tmux-server`.

Conflicts: scripts/copycat_mode_bindings.sh. I fixed the conflict and tested
that it can select tokens/URLs, that I can scroll with it (which I couldn't
before this reversion). I'm not sure it won't introduce bugs, but it definitely
fixes the regression mentioned above.

I don't have much experience with this codebase, so I'm wondering if @gpanders
(original committer) if they could assist on fixing this commit and
re-reverting. Thanks.